### PR TITLE
Fix naming in Arm name 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *pyc
 *.idea/
+*.egg-info
+__pycache__/

--- a/GaitCore/Bio/Arm.py
+++ b/GaitCore/Bio/Arm.py
@@ -47,7 +47,7 @@
 
 
 
-class Arn(object):
+class Arm(object):
     """
     Hold the joints of a leg
     """

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ import setuptools
 
 setuptools.setup(
     name="GaitCore",
-    version="1.3.1",
+    version="1.3.2",
     packages=setuptools.find_packages()
 )


### PR DESCRIPTION
Fix name of class from `Arn` to `Arm`

Increment version by 0.0.1 to reflect change

Add .egg-info + other temporary python files to the .gitignore